### PR TITLE
fix hookOverloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,7 +1640,7 @@ function hookOverloads(className, func) {
   var clazz = Java.use(className);
   var overloads = clazz[func].overloads;
   for (var i in overloads) {
-    if (overloads[i].hasOwnProperty('argumentTypes')) {
+    if (overloads[i].hasOwnProperty('argumentTypes') || overloads[i]['argumentTypes'] != undefined) {
       var parameters = [];
 
       var curArgumentTypes = overloads[i].argumentTypes, args = [], argLog = '[';


### PR DESCRIPTION
`overloads[i].hasOwnProperty('argumentTypes')` will return false even if it has argumentTypes property on android device.